### PR TITLE
Refactor dataset loading logic

### DIFF
--- a/games_analyzer.py
+++ b/games_analyzer.py
@@ -346,50 +346,43 @@ class GameDataset:
             out[key] = "" if val is None else str(val)
         return out
 
+    def _read_games(self, csv_path: Path, record_invalid: bool) -> list[Game]:
+        csv_path = Path(csv_path)
+        if not csv_path.exists():
+            raise DataValidationError(f"Arquivo CSV não encontrado: {csv_path}")
+        games: list[Game] = []
+        if record_invalid:
+            self.invalid_rows_count = 0
+            self.invalid_rows_detail = []
+        with csv_path.open("r", encoding="utf-8-sig", newline="") as f:
+            reader = csv.DictReader(f)
+            fieldnames = list(reader.fieldnames or [])
+            field_map = self._build_field_map(fieldnames)
+            if record_invalid:
+                self.loaded_field_map = field_map
+            for idx, row in enumerate(reader, start=2):
+                try:
+                    norm = self._normalize_row(row, field_map)
+                    game = GameParser.parse(norm)
+                    games.append(game)
+                except DataValidationError as e:
+                    if record_invalid:
+                        self.invalid_rows_count += 1
+                        self.invalid_rows_detail.append((idx, str(e)))
+                    continue
+        return games
+
     def load(self) -> list[Game]:
         """Lê o CSV principal e retorna lista de Game (fail-soft).
 
         Agora aceita `Genres` vazio (vira lista []), e só marca inválido quando
         há um problema essencial (ex.: `Name` vazio).
         """
-        if not self.csv_path.exists():
-            raise DataValidationError(f"Arquivo CSV não encontrado: {self.csv_path}")
-        games: list[Game] = []
-        self.invalid_rows_count = 0
-        self.invalid_rows_detail = []
-        with self.csv_path.open("r", encoding="utf-8-sig", newline="") as f:
-            reader = csv.DictReader(f)
-            fieldnames = list(reader.fieldnames or [])
-            field_map = self._build_field_map(fieldnames)
-            self.loaded_field_map = field_map
-            for idx, row in enumerate(reader, start=2):  # 1 = cabeçalho
-                try:
-                    norm = self._normalize_row(row, field_map)
-                    game = GameParser.parse(norm)
-                    games.append(game)
-                except DataValidationError as e:
-                    self.invalid_rows_count += 1
-                    self.invalid_rows_detail.append((idx, str(e)))
-                    continue
-        return games
+        return self._read_games(self.csv_path, record_invalid=True)
 
     def load_from_file(self, csv_file: Path) -> list[Game]:
         """Carrega jogos de qualquer CSV (mesma lógica de parsing/normalização)."""
-        if not Path(csv_file).exists():
-            raise DataValidationError(f"Arquivo CSV não encontrado: {csv_file}")
-        games: list[Game] = []
-        with Path(csv_file).open("r", encoding="utf-8-sig", newline="") as f:
-            reader = csv.DictReader(f)
-            fieldnames = list(reader.fieldnames or [])
-            field_map = self._build_field_map(fieldnames)
-            for idx, row in enumerate(reader, start=2):
-                try:
-                    norm = self._normalize_row(row, field_map)
-                    game = GameParser.parse(norm)
-                    games.append(game)
-                except DataValidationError:
-                    continue
-        return games
+        return self._read_games(Path(csv_file), record_invalid=False)
 
     def sample_once(self, output_dir: Path, k: int = 20, seed: int = 1234) -> Path:
         """Cria sample/sample.csv determinística (não sobrescreve se existir).


### PR DESCRIPTION
## Summary
- add `_read_games` helper to centralize CSV parsing and optional invalid-row tracking
- call helper from `load` and `load_from_file` to eliminate duplication

## Testing
- `python games_analyzer.py --csv sample/sample.csv --run-internal-tests`
- `python games_analyzer.py --csv sample/sample.csv --run-sample-tests`


------
https://chatgpt.com/codex/tasks/task_e_68ae5f461114832c9334ba337c327c37