### PR TITLE
refactor: streamline GameParser field normalization

### DIFF
--- a/games_analyzer.py
+++ b/games_analyzer.py
@@ -253,21 +253,18 @@ class GameParser:
         >>> g.genres
         ['Action', 'Indie']
         """
-        # Normaliza valores a strings (ou "")
-        def norm(v: Any) -> str:
-            if v is None:
-                return ""
-            return str(v)
+        # Normaliza valores a strings (ou "") via compreensão
+        fields = {
+            k: str(row.get(k, "") or "").strip()
+            for k in ("Name", "Release date", "Price", "Genres", "Developers", "Publishers")
+        }
 
-        name = norm(row.get("Name")).strip()
-        rel = norm(row.get("Release date")).strip()
-        price_raw = norm(row.get("Price")).strip()
-        genres_raw = norm(row.get("Genres")).strip()
-        dev = norm(row.get("Developers")).strip()
-        pub = norm(row.get("Publishers")).strip()
-
-        if not name:
-            name = None
+        name = fields["Name"] or None
+        rel = fields["Release date"]
+        price_raw = fields["Price"]
+        genres_raw = fields["Genres"]
+        dev = fields["Developers"]
+        pub = fields["Publishers"]
 
         price = GameParser.parse_price(price_raw)
         year = GameParser.parse_year(rel)
@@ -275,14 +272,8 @@ class GameParser:
 
         is_free = (price == 0.0) if (price is not None) else False
 
-        raw_norm = {
-            "Name": name or "",
-            "Release date": rel,
-            "Price": price_raw,
-            "Genres": genres_raw,
-            "Developers": dev,
-            "Publishers": pub,
-        }
+        raw_norm = fields.copy()
+        raw_norm["Name"] = name or ""
 
         return Game(
             name=name,


### PR DESCRIPTION
## Summary
- normalize relevant CSV columns in one dictionary comprehension
- reuse normalized fields in `GameParser.parse` and preserve optional name

## Testing
- `python -m doctest -v games_analyzer.py`
- `python games_analyzer.py --csv sample/sample.csv --run-sample-tests`


------
https://chatgpt.com/codex/tasks/task_e_68ae5f468edc832ca677ecd1734487c8