### PR TITLE
Add CLI options for quiet mode and genre limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ python games_analyzer.py --csv steam_games.csv
 Para gerar o relatório:
 python games_analyzer.py --csv steam_games.csv --report report.md
 
-Para ver detalhes das linhas realmente inválidas (ex.: Name vazio):
-python games_analyzer.py --csv steam_games.csv --debug-invalid
+Para suprimir saídas, ver detalhes das linhas inválidas e limitar gêneros (ex.: top 10):
+python games_analyzer.py --csv steam_games.csv --quiet --debug-invalid --top-n 10
+

--- a/games_analyzer.py
+++ b/games_analyzer.py
@@ -826,6 +826,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
                    help="Roda doctest + unittest embutidos.")
     p.add_argument("--report", type=Path, default=None,
                    help="Gera report.md no caminho indicado.")
+    p.add_argument("--quiet", action="store_true",
+                   help="Suprime saídas.")
+    p.add_argument("--debug-invalid", action="store_true",
+                   help="Exibe detalhes de linhas inválidas.")
+    p.add_argument("--top-n", type=int, default=5,
+                   help="Limita o número de gêneros.")
     return p
 
 


### PR DESCRIPTION
## Summary
- Add `--quiet`, `--debug-invalid`, and `--top-n` options to the CLI
- Document new CLI options in README

## Testing
- `python games_analyzer.py --csv sample/sample.csv --run-internal-tests`
- `python games_analyzer.py --csv sample/sample.csv --debug-invalid --top-n 3`
- `python games_analyzer.py --csv sample/sample.csv --quiet --top-n 2`


------
https://chatgpt.com/codex/tasks/task_e_68b101aa91ec832c8475e0fd78e25bdf