### PR TITLE
fix: format GameParser.parse doctest example

### DIFF
--- a/games_analyzer.py
+++ b/games_analyzer.py
@@ -241,7 +241,14 @@ class GameParser:
         is_free = (price == 0.0) quando price válido; caso inválido → price=None e is_free=False.
         Se "Name" estiver vazio, o atributo ``name`` será ``None``.
 
-        >>> r = {'Name':'Foo', 'Release date':'Oct 21, 2008', 'Price':'0.00', 'Genres':'Action, Indie', 'Developers':'ACME', 'Publishers':'ACME'}
+        >>> r = {
+        ...     'Name': 'Foo',
+        ...     'Release date': 'Oct 21, 2008',
+        ...     'Price': '0.00',
+        ...     'Genres': 'Action, Indie',
+        ...     'Developers': 'ACME',
+        ...     'Publishers': 'ACME'
+        ... }
         >>> g = GameParser.parse(r)
         >>> g.is_free
         True


### PR DESCRIPTION
## Summary
- format GameParser.parse docstring example using ellipsis
- ensure 'ACME' publisher/developer values remain on single lines

## Testing
- `python -m doctest -v games_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_e_68b101ab9168832cbb304938ffb5fac6